### PR TITLE
Pull ruby path handling out into helper functions to facilitate viewing private source code

### DIFF
--- a/src/utils/ruby-paths.js
+++ b/src/utils/ruby-paths.js
@@ -1,0 +1,11 @@
+export function rubyGemDownloadRecipe(parsedFile) {
+  const { gem, path } = parsedFile;
+  return {
+    type: 'CORS_ENABLED_SINGLE_FILE',
+    url: `https://gems.vernier.prof/${gem}/${path}`
+  };
+}
+
+export function normalPathCatchall(parsedFile) {
+  return { type: 'NO_KNOWN_CORS_URL' };
+}

--- a/src/utils/special-paths.js
+++ b/src/utils/special-paths.js
@@ -5,6 +5,7 @@
 // @flow
 
 import { assertExhaustiveCheck } from 'firefox-profiler/utils/flow';
+import { rubyGemDownloadRecipe, normalPathCatchall } from 'firefox-profiler/utils/ruby-paths';
 import { PROFILER_SERVER_ORIGIN } from 'firefox-profiler/app-logic/constants';
 
 export type ParsedFileNameFromSymbolication =
@@ -275,14 +276,10 @@ export function getDownloadRecipeForSourceFile(
       };
     }
     case 'gem': {
-      const { gem, path } = parsedFile;
-      return {
-        type: 'CORS_ENABLED_SINGLE_FILE',
-        url: `https://gems.vernier.prof/${gem}/${path}`
-      };
+      return rubyGemDownloadRecipe(parsedFile);
     }
     case 'normal': {
-      return { type: 'NO_KNOWN_CORS_URL' };
+      return normalPathCatchall(parsedFile);
     }
     default:
       throw assertExhaustiveCheck(parsedFile.type, 'unhandled ParsedFile type');


### PR DESCRIPTION
# What

This should have no functional changes, but is meant to facilitate swapping out the implementation of some special path handling in order to view privately hosted source code.

# Why

We'd like to make it easy for developers at Shopify to have the added context of private source code alongside their vernier profiles, and also not abuse the public gem source cody proxying that gems.vernier.prof is doing for public gems.

# How

In order to proxy source code for private github repos and private ruby gems, it is helpful to hook into the existing handling in "special-paths.js".

The current defaults point "gems" at `gems.vernier.prof`, and the fallback for "normal" is to throw a CORS error.

Both of these can be pointed at a different server address which hosts internal, private gems. Doing so however requires maintaining a fork of the "ruby" branch of this fork, which is a bit clunky.

The solution I've come up with is to move the implementation of the gem and normal path handlers to a helper file, "ruby-paths.js".  This way, rather than maintain a fork, a separate copy of this file can be used like "ruby-paths-internal.js" that just replaces these functions with a different implementation, and only one line (the import line) in special-paths.js needs to be changed. The implementation of "ruby-paths-intersal.js" can be stored in lieu of trying apply a patch.

In the internal implementation, a proxy that runs at the same domain can provide private source code from github with a path like:

```
/src?repo=my-repo&path=/some/path/in/repo&ref=some-git-ref
```

And gems like:

```
/src?gem=vernier-1.5.0&path=lib/version.rb
```

etc.