### PR TITLE
Avoid CORS issues on same host by default to empty params if URL starts with /

### DIFF
--- a/src/utils/query-api.js
+++ b/src/utils/query-api.js
@@ -144,7 +144,9 @@ export class RegularExternalCommunicationDelegate
             mode: 'cors',
             credentials: 'omit',
           }
-        : { credentials: 'omit' };
+        : url.startsWith('/')
+          ? {}
+          : { credentials: 'omit' };
     const response = await fetch(url, requestInit);
     if (response.status !== 200) {
       throw new Error(


### PR DESCRIPTION
# What

Avoid CORS issues if requesting sources hosted on the same domain

# Why

Fetch, if called with non-empty params, will complain about CORS issues. We default to having `{ credentials: 'omit' }`, which for whatever reason causes the browser to complain about CORS issues.

Note that this is in support of internal gem hosting as done in #9

# How

If it is detected that the URL to fetch is hosted on the same domain, as determined by it starting with a leading `/`, we omit all params. This "plain get" avoids the CORS issues and allows the API request to succed.