### PR TITLE
Allow overriding ruby recipes with hook functions if defined

### DIFF
--- a/src/utils/ruby-hooks.js
+++ b/src/utils/ruby-hooks.js
@@ -1,0 +1,18 @@
+export async function tryLoadRubyHooks() {
+    try {
+        const context = require.context('./', false, /ruby-custom-hooks\.js$/);
+        const hookModule = context('./ruby-custom-hooks.js');
+
+        if (hookModule) {
+          return {
+              rubyGemDownloadRecipe: hookModule.rubyGemDownloadRecipe,
+              normalPathCatchall: hookModule.normalPathCatchall
+          };
+        } else {
+          return null;
+        }
+    } catch (error) {
+        // no hooks were defined, the default behaviour will be used
+    }
+    return null;
+}

--- a/src/utils/special-paths.js
+++ b/src/utils/special-paths.js
@@ -5,6 +5,7 @@
 // @flow
 
 import { assertExhaustiveCheck } from 'firefox-profiler/utils/flow';
+import { tryLoadRubyHooks } from 'firefox-profiler/utils/ruby-hooks';
 import { PROFILER_SERVER_ORIGIN } from 'firefox-profiler/app-logic/constants';
 
 export type ParsedFileNameFromSymbolication =
@@ -275,6 +276,9 @@ export function getDownloadRecipeForSourceFile(
       };
     }
     case 'gem': {
+      if (typeof rubyGemDownloadRecipe === 'function') {
+        return rubyGemDownloadRecipe(parsedFile);
+      }
       const { gem, path } = parsedFile;
       return {
         type: 'CORS_ENABLED_SINGLE_FILE',
@@ -282,9 +286,23 @@ export function getDownloadRecipeForSourceFile(
       };
     }
     case 'normal': {
+      if (typeof normalPathCatchall === 'function') {
+        return normalPathCatchall(parsedFile);
+      }
       return { type: 'NO_KNOWN_CORS_URL' };
     }
     default:
       throw assertExhaustiveCheck(parsedFile.type, 'unhandled ParsedFile type');
   }
 }
+
+let rubyGemDownloadRecipe;
+let normalPathCatchall;
+
+(async () => {
+    const symbols = await tryLoadRubyHooks();
+    if (symbols) {
+        rubyGemDownloadRecipe = symbols.rubyGemDownloadRecipe;
+        normalPathCatchall = symbols.normalPathCatchall;
+    }
+})();


### PR DESCRIPTION
Replaces an earlier attempt, #7 

To be useful (assuming the private source proxy is running on the same host serving firefox-profiler), this also requires #8 

# What

This should have no functional changes, but is meant to facilitate swapping out the implementation of some special path handling in order to view privately hosted source code.

# Why

We'd like to make it easy for developers at Shopify (or any company) to have the added context of private source code alongside their vernier profiles, and also not abuse the public gem source cody proxying that gems.vernier.prof is doing for public gems.

# How

In order to proxy source code for private github repos and private ruby gems, it is helpful to hook into the existing handling in "special-paths.js".

The current defaults point "gems" at `gems.vernier.prof`, and the fallback for "normal" is to throw a CORS error.

Both of these can be pointed at a different server address which hosts internal, private gems. Doing so however requires maintaining a fork of the "ruby" branch of this fork, which is a bit clunky.

The approach I have come up with that I think is a decent compromise is to check if specific hook functions are defined, and call those or else fall back to the current behaviour as the default.

To define these hooks, they are placed in a special file which will attempt to be loaded using webpack's `require.context`, `ruby-custom-hooks.js`. Here is a sample usage:

```js
export function rubyGemDownloadRecipe(parsedFile) {
  const { gem, path } = parsedFile;
  return {
    type: 'CORS_ENABLED_SINGLE_FILE',
    url: `/src?gem=${gem}&path=${path}`
  };
}

export function normalPathCatchall(parsedFile) {
  const { path } = parsedFile;
  const meta = getState().profileView.profile.meta;

  // look for metadata similar to what is used in grafana's github integration to help the server find the source code
  // https://grafana.com/docs/grafana-cloud/monitor-applications/profiles/pyroscope-github-integration/#application-with-profiling-data-requirements

  const repo = meta.service_repository || "";
  const ref = meta.service_git_ref || "";
  const root = meta.service_root_path || "";

  return {
    type: 'CORS_ENABLED_SINGLE_FILE',
    url: `/src?repo=${repo}&ref=${ref}&path=${path}&root=${root}`
  };
}
```

This way, at build time this file can simply be copied in before running webpack, and there is no need to maintain a fork in order to use private source code proxy endpoints. If the file is not copied in, the default behaviour is used as the hook functions are undefined.