### PR TITLE
Replace webpack require.context with dynamic import in ruby-hooks

### DIFF
--- a/src/utils/ruby-hooks.js
+++ b/src/utils/ruby-hooks.js
@@ -1,7 +1,6 @@
 export async function tryLoadRubyHooks() {
     try {
-        const context = require.context('./', false, /ruby-custom-hooks\.js$/);
-        const hookModule = context('./ruby-custom-hooks.js');
+        const hookModule = await import('./ruby-custom-hooks.js');
 
         if (hookModule) {
           return {


### PR DESCRIPTION
Upstream commit https://github.com/tenderlove/profiler/commit/c0b82be3f0bf27130a8201b8956ed27923a3a12c swapped webpack to esbuild, which broke https://github.com/firefox-devtools/profiler/commit/af9aef7cfa23b9e54aaf5785cfd7f16de21ea5b7 when we rebased.

require.context is a webpack-specific API that doesn't exist in esbuild. The try/catch silently swallowed the error, so custom hooks were never loaded and gem requests always fell through to the default URL.

Use standard dynamic import() instead. Ship a default no-op ruby-custom-hooks.js so the import always resolves. Consumers can overwrite this file before building to inject custom download hooks.

