### PR TITLE
Fix viewing localhost source files

### DIFF
--- a/src/utils/special-paths.ts
+++ b/src/utils/special-paths.ts
@@ -183,7 +183,7 @@ export function parseFileNameFromSymbolication(
     const { host, path } = localhostMatch.groups;
     return {
       type: 'localhost',
-      host: location.host + '/source',
+      host: host + '/source',
       path,
     };
   }


### PR DESCRIPTION
Local project source code files cannot be fetched because the URL is malformed and missing the protocol.

`location.host` does not include `http://`, though the protocol is present in the regex match, see screenshot below.

<img width="1199" height="596" alt="Screenshot 2026-04-06 at 08 39 29" src="https://github.com/user-attachments/assets/b4cf13a2-c9ef-4b0e-841c-2dfeed49aead" />

It also appears that fetching gem code from `https://gems.vernier.prof` isn't working, but I think that looks to be a separate issue, potentially a server side issue?

```
❯ curl https://gems.vernier.prof/actionpack-7.0.8.7/lib/action_dispatch/middleware/callbacks.rb
curl: (35) LibreSSL SSL_connect: SSL_ERROR_SYSCALL in connection to gems.vernier.prof:443
```